### PR TITLE
修复全局隐藏TopBar只在Tab布局下生效的问题

### DIFF
--- a/android/src/main/java/com/reactnative/hybridnavigation/Garden.java
+++ b/android/src/main/java/com/reactnative/hybridnavigation/Garden.java
@@ -74,7 +74,7 @@ public class Garden {
         this.options = options;
 
         this.swipeBackEnabled = options.getBoolean("swipeBackEnabled", true);
-        this.toolbarHidden = options.getBoolean("topBarHidden", false);
+        this.toolbarHidden = options.getBoolean("topBarHidden", globalStyle.getOptions().getBoolean("topBarHidden", false));
         Bundle tabItem = options.getBundle("tabItem");
         this.hidesBottomBarWhenPushed = tabItem == null || tabItem.getBoolean("hideTabBarWhenPush", true);
         this.extendedLayoutIncludesTopBar = options.getBoolean("extendedLayoutIncludesTopBar", false);


### PR DESCRIPTION
sorry，之前提交的PR[#228 ]只在Tab布局发现会自动隐藏，刚刚发现stack布局还是有topbar的，在这里修复了。

另外我们这个库是否支持tablet设备上横屏状态下TabBar改变位置？就是类似于很多iPad应用，将TabBar放到了左侧，我自己现在通过findViewById硬改实现了，想问一下有没有优雅点的方案呢？